### PR TITLE
remove debugging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,10 @@ php:
 - 7
 - 7.1
 
+install:
+  - travis_retry composer install $COMPOSER_ARGS
+  - composer show
+
 script:
-  - php debugEnvVar.php
+  - composer test
   - sonar-scanner

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ php:
 - 7.1
 
 install:
-  - travis_retry composer install $COMPOSER_ARGS
+  - travis_retry composer update $COMPOSER_ARGS
   - composer show
 
 script:

--- a/debugEnvVar.php
+++ b/debugEnvVar.php
@@ -1,7 +1,0 @@
-<?php
-$dummyVarEnv = getenv('DUMMY_VAR');
-echo "Value of DUMMY_VAR:\n";
-var_dump($dummyVarEnv);
-$authData = json_decode($dummyVarEnv, true);
-echo "Converted into array with json_decode:\n";
-var_dump($authData);


### PR DESCRIPTION
We've probably figured out how to format the content of the variable COMPOSER_AUTH:
 - escape all quotes
 - remove all white spaces
 - escape the comma (!!)

Now we can remove the debugging code:
 - removed debugEnvVar.php;
 - set .travis.yml back to normal