### PR TITLE
Maestro: specifying wrappingDivId at submit

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/creditcard.js
+++ b/view/frontend/web/js/view/payment/method-renderer/creditcard.js
@@ -54,7 +54,8 @@ define(
             seamlessFormSubmit: function() {
                 WirecardPaymentPage.seamlessSubmitForm({
                     onSuccess: this.seamlessFormSubmitSuccessHandler.bind(this),
-                    onError: this.seamlessFormSubmitErrorHandler.bind(this)
+                    onError: this.seamlessFormSubmitErrorHandler.bind(this),
+                    wrappingDivId: this.getCode() + '_seamless_form'
                 });
             },
             seamlessFormSubmitSuccessHandler: function (response) {


### PR DESCRIPTION
# Payment with credit card or Maestro
At submitting the seamless form: specifying wrappingDivId  
so that it can be determined which iframe has to be submitted.

