### PR TITLE
Add fallback locale

### DIFF
--- a/Model/Ui/ConfigProvider.php
+++ b/Model/Ui/ConfigProvider.php
@@ -106,6 +106,12 @@ class ConfigProvider implements ConfigProviderInterface
         $this->checkoutSession = $session;
         $this->store = $store;
         $this->storeManager = $storeManager;
+
+        $locales = array('de_DE', 'en_US', 'id_ID', 'ja_JP', 'ko_KR', 'zh_Hans_CN', 'zh_Hant_TW');
+
+        if (!in_array($store->getLocale(), $locales)) {
+            $this->store->setLocale('en_US');
+        }
     }
 
     /**

--- a/Model/Ui/ConfigProvider.php
+++ b/Model/Ui/ConfigProvider.php
@@ -43,6 +43,8 @@ use Wirecard\PaymentSdk\Entity\IdealBic;
 
 class ConfigProvider implements ConfigProviderInterface
 {
+    const FALLBACK_LOCALE = 'en_US';
+    const LOCALES = array('de_DE', 'en_US', 'id_ID', 'ja_JP', 'ko_KR', 'zh_Hans_CN', 'zh_Hant_TW');
     const PAYPAL_CODE = 'wirecard_elasticengine_paypal';
     const CREDITCARD_CODE = 'wirecard_elasticengine_creditcard';
     const MAESTRO_CODE = 'wirecard_elasticengine_maestro';
@@ -107,10 +109,8 @@ class ConfigProvider implements ConfigProviderInterface
         $this->store = $store;
         $this->storeManager = $storeManager;
 
-        $locales = array('de_DE', 'en_US', 'id_ID', 'ja_JP', 'ko_KR', 'zh_Hans_CN', 'zh_Hant_TW');
-
-        if (!in_array($store->getLocale(), $locales)) {
-            $this->store->setLocale('en_US');
+        if (!in_array($store->getLocale(), self::LOCALES)) {
+            $this->store->setLocale(self::FALLBACK_LOCALE);
         }
     }
 


### PR DESCRIPTION
### This PR

* If current locale is not supported (there is no .csv file for that locale in i18n folder), set locale to default "en_US"

### Notes

* Payment method title on checkout page is being shown as a key. Fix for this is included in this [PR](https://github.com/wirecard/magento2-ee/pull/178).

### How to test

* Go to admin panel and navigate to Stores->General->General->Locale Options
* Select some locale which is currently not supported
* Go to checkout page on frontend
* You will see English (fallback) translation in the form