### PR TITLE
remove layout parameter

### DIFF
--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -31,7 +31,8 @@
  */
 -->
 
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="head.additional">
             <block class="Wirecard\ElasticEngine\Block\Checkout\PaymentPageLoader" template="Wirecard_ElasticEngine::payment-page-loader.phtml" name="elastic.checkout.script" />

--- a/view/frontend/layout/checkout_onepage_success.xml
+++ b/view/frontend/layout/checkout_onepage_success.xml
@@ -30,7 +30,7 @@
  * Please do not use the plugin if you do not agree to these terms of use!
  */
 -->
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column"
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="order.success.additional.info">


### PR DESCRIPTION
The layout in [checkout_index_index](https://github.com/magento/magento2/blob/2.3-develop/app/code/Magento/Checkout/view/frontend/layout/checkout_index_index.xml) is set to layout="checkout". The extension overwrites this to layout="1column". For compatibility reasons the layout shouldn't be set if no change is forced, so I removed it.