### PR TITLE
Prevent recursive translation call

### DIFF
--- a/Model/TranslationFallback.php
+++ b/Model/TranslationFallback.php
@@ -20,6 +20,11 @@ class TranslationFallback extends \Magento\Framework\Phrase\Renderer\Translate
      * @var array
      */
     private $fallbackTranslations = null;
+    
+    /**
+     * @var bool
+     */
+    private $fallbackTranslationsLoading;
 
     /**
      * Wrapper function to intercept translation from Core Magento2 functionality.
@@ -35,19 +40,25 @@ class TranslationFallback extends \Magento\Framework\Phrase\Renderer\Translate
      */
     public function aroundRender(\Magento\Framework\Phrase\Renderer\Translate $subject, callable $proceed, array $source, array $arguments)
     {
-        if (!$this->fallbackTranslations) {
-            $originalLocale = $subject->translator->getLocale();
-            $subject->translator->setLocale($this->fallbackLocale);
-            $subject->translator->loadData(null, true);
+        if (!$this->fallbackTranslations && !$this->fallbackTranslationsLoading) {
+            $this->fallbackTranslationsLoading = true;
 
             try {
-                $this->fallbackTranslations = $subject->translator->getData();
-            } catch (\Exception $e) {
-                $subject->logger->critical($e->getMessage());
-                throw $e;
+                $originalLocale = $subject->translator->getLocale();
+                $subject->translator->setLocale($this->fallbackLocale);
+                $subject->translator->loadData(null, true);
+
+                try {
+                    $this->fallbackTranslations = $subject->translator->getData();
+                } catch (\Exception $e) {
+                    $subject->logger->critical($e->getMessage());
+                    throw $e;
+                }
+                $subject->translator->setLocale($originalLocale);
+                $subject->translator->loadData(null, true);
+            } finally {
+                $this->fallbackTranslationsLoading = false;
             }
-            $subject->translator->setLocale($originalLocale);
-            $subject->translator->loadData(null, true);
         }
 
         $translationKey = end($source);


### PR DESCRIPTION
Since loadData() can cause additional translations, which will lead to a recursive call to the aroundRenderer() function, we can interrupt the recursive call to prevent this behavior by setting a flag.

Updates #225
