### PR TITLE
Fix `form_key invalid` for cancel controller

### DIFF
--- a/Controller/Frontend/Cancel.php
+++ b/Controller/Frontend/Cancel.php
@@ -21,9 +21,10 @@ use Magento\Sales\Api\OrderRepositoryInterface;
  * Class Cancel
  * @package Wirecard\ElasticEngine\Controller\Frontend
  */
-class Cancel extends Action
+class Cancel extends Action implements CsrfAwareActionInterface
 {
-
+    use NoCsrfTrait;
+    
     /**
      * @var Session
      */

--- a/Controller/Frontend/Cancel.php
+++ b/Controller/Frontend/Cancel.php
@@ -12,6 +12,7 @@ namespace Wirecard\ElasticEngine\Controller\Frontend;
 use Magento\Checkout\Model\Session;
 use Magento\Framework\App\Action\Action;
 use Magento\Framework\App\Action\Context;
+use Magento\Framework\App\CsrfAwareActionInterface;
 use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\Controller\Result\Redirect as RedirectResult;
 use Magento\Framework\Controller\ResultFactory;


### PR DESCRIPTION
This controller should implement the NoCsrfTrait, just like the notify and redirect controllers do.