### PR TITLE
Refactoring of the PHP code for Credit Card

### DIFF
--- a/Block/Checkout/CreditCardThreeDForm.php
+++ b/Block/Checkout/CreditCardThreeDForm.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Shop System Plugins:
+ * - Terms of Use can be found under:
+ * https://github.com/wirecard/magento2-ee/blob/master/_TERMS_OF_USE
+ * - License can be found under:
+ * https://github.com/wirecard/magento2-ee/blob/master/LICENSE
+ */
+
+namespace Wirecard\ElasticEngine\Block\Checkout;
+
+use Magento\Framework\View\Element\Template;
+use Wirecard\PaymentSdk\Entity\FormFieldMap;
+use Wirecard\PaymentSdk\Response\FormInteractionResponse;
+
+/**
+ * This class is for creating a Credit Card three d form
+ *
+ * Class CreditCardThreeDForm
+ * @package Wirecard\ElasticEngine\Block\Checkout
+ * @since 3.1.2
+ */
+class CreditCardThreeDForm extends Template
+{
+    /** @var FormInteractionResponse */
+    private $response;
+
+    /**
+     * @param FormInteractionResponse $response
+     * @since 3.1.2
+     */
+    public function setResponse($response)
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * @return string
+     * @since 3.1.2
+     */
+    public function getMethod()
+    {
+        return $this->response->getMethod();
+    }
+
+    /**
+     * @return string
+     * @since 3.1.2
+     */
+    public function getAction()
+    {
+        return urldecode($this->response->getUrl());
+    }
+
+    /**
+     * @return FormFieldMap
+     * @since 3.1.2
+     */
+    public function getFormFields()
+    {
+        return $this->response->getFormFields();
+    }
+}

--- a/Controller/Frontend/Callback.php
+++ b/Controller/Frontend/Callback.php
@@ -127,16 +127,7 @@ class Callback extends Action
             $this->session->unsRedirectUrl();
             return $data;
         }
-        if ($this->session->hasFormUrl()) {
-            $data['form-url'] = $this->session->getFormUrl();
-            $data['form-method'] = $this->session->getFormMethod();
-            $data['form-fields'] = $this->session->getFormFields();
 
-            $this->session->unsFormUrl();
-            $this->session->unsFormMethod();
-            $this->session->unsFormFields();
-            return $data;
-        }
         $data[self::REDIRECT_URL] = $this->baseUrl . 'frontend/redirect';
         return $data;
     }

--- a/Controller/Frontend/Callback.php
+++ b/Controller/Frontend/Callback.php
@@ -16,6 +16,7 @@ use Magento\Framework\App\Request\Http;
 use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\View\Result\Layout;
 use Psr\Log\LoggerInterface;
 use Wirecard\ElasticEngine\Gateway\Helper;
 use Wirecard\ElasticEngine\Gateway\Service\TransactionServiceFactory;
@@ -135,16 +136,13 @@ class Callback extends Action
         $order = $this->session->getLastRealOrder();
         $this->paymentHelper->addTransaction($order->getPayment(), $response, true);
 
-        // create html response
-        if ($response instanceof FormInteractionResponse) {
-            $data['form-url'] = html_entity_decode($response->getUrl());
-            $data['form-method'] = $response->getMethod();
-            foreach ($response->getFormFields() as $key => $value) {
-                $data[$key] = html_entity_decode($value);
-            }
-        }
+        /** @var Layout $page */
+        $page = $this->resultFactory->create(ResultFactory::TYPE_LAYOUT);
+        $block = $page->getLayout()->getBlock('frontend.creditcardthreedform');
+        $block->setResponse($response);
+        $page->setHttpResponseCode('200');
 
-        return $data;
+        return $page;
     }
 
     /**

--- a/Controller/Frontend/Callback.php
+++ b/Controller/Frontend/Callback.php
@@ -31,6 +31,7 @@ use Wirecard\PaymentSdk\TransactionService;
  * Class Callback
  * @package Wirecard\ElasticEngine\Controller\Frontend
  * @method Http getRequest()
+ * @since 3.1.2 Reworked handling of callback
  */
 class Callback extends Action
 {
@@ -89,6 +90,7 @@ class Callback extends Action
      * @return \Magento\Framework\Controller\ResultInterface
      * @throws LocalizedException
      * @throws \Http\Client\Exception
+     * @since 3.1.2 Update return results, adding of page result for three d flow
      */
     public function execute()
     {
@@ -120,6 +122,7 @@ class Callback extends Action
      * @return mixed
      * @throws LocalizedException
      * @throws \Http\Client\Exception
+     * @since 3.1.2 Update handling
      */
     private function handleThreeDTransactions($response)
     {
@@ -147,6 +150,7 @@ class Callback extends Action
 
     /**
      * @return bool
+     * @since 3.1.2
      */
     private function isCreditCardThreeD()
     {
@@ -160,6 +164,7 @@ class Callback extends Action
     /**
      * @param string $redirectUrl
      * @return Json
+     * @since 3.1.2
      */
     private function createRedirectResult($redirectUrl)
     {

--- a/Gateway/Response/ResponseHandler.php
+++ b/Gateway/Response/ResponseHandler.php
@@ -88,7 +88,6 @@ class ResponseHandler implements HandlerInterface
      */
     public function handle(array $handlingSubject, array $response)
     {
-        $this->logger->debug('im processing the response');
         /** @var Response $sdkResponse */
         $sdkResponse = $response['paymentSDK-php'];
 

--- a/Gateway/Response/ResponseHandler.php
+++ b/Gateway/Response/ResponseHandler.php
@@ -88,6 +88,7 @@ class ResponseHandler implements HandlerInterface
      */
     public function handle(array $handlingSubject, array $response)
     {
+        $this->logger->debug('im processing the response');
         /** @var Response $sdkResponse */
         $sdkResponse = $response['paymentSDK-php'];
 
@@ -107,18 +108,6 @@ class ResponseHandler implements HandlerInterface
 
             $this->paymentHelper->addTransaction($payment, $sdkResponse);
         } elseif ($sdkResponse instanceof FormInteractionResponse) {
-            $this->session->setFormMethod($sdkResponse->getMethod());
-            $this->session->setFormUrl($sdkResponse->getUrl());
-
-            $formFields = [];
-            foreach ($sdkResponse->getFormFields() as $key => $value) {
-                $formFields[] = [
-                    'key' => $key,
-                    'value' => $value
-                ];
-            }
-            $this->session->setFormFields($formFields);
-
             $postfix = '';
             // add postfix for vault checkouts to avoid overwritten sales_payment_transactions
             // when processing the notify

--- a/Gateway/Response/ResponseHandler.php
+++ b/Gateway/Response/ResponseHandler.php
@@ -99,9 +99,6 @@ class ResponseHandler implements HandlerInterface
 
         // clear session variables
         $this->session->unsRedirectUrl();
-        $this->session->unsFormMethod();
-        $this->session->unsFormUrl();
-        $this->session->unsFormFields();
 
         if ($sdkResponse instanceof InteractionResponse) {
             $this->session->setRedirectUrl($sdkResponse->getRedirectUrl());

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "wirecard/magento2-ee",
-  "description": "Magento2 plugin for Wirecard Payment Processing Gateway",
+  "description": "Wirecard Magento 2 Extension",
   "license": "GPL-3.0-only",
   "minimum-stability": "beta",
   "prefer-stable": true,

--- a/view/frontend/layout/wirecard_elasticengine_frontend_callback.xml
+++ b/view/frontend/layout/wirecard_elasticengine_frontend_callback.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Shop System Plugins:
+ * - Terms of Use can be found under:
+ * https://github.com/wirecard/magento2-ee/blob/master/_TERMS_OF_USE
+ * - License can be found under:
+ * https://github.com/wirecard/magento2-ee/blob/master/LICENSE
+ */
+-->
+
+<layout xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/layout_generic.xsd">
+    <container name="root">
+        <block class="Wirecard\ElasticEngine\Block\Checkout\CreditCardThreeDForm" template="Wirecard_ElasticEngine::creditcardthreedform.phtml" name="frontend.creditcardthreedform" cacheable="false" />
+</container>
+</layout>

--- a/view/frontend/layout/wirecard_elasticengine_frontend_sepamandate.xml
+++ b/view/frontend/layout/wirecard_elasticengine_frontend_sepamandate.xml
@@ -34,6 +34,3 @@
         <referenceContainer name="copyright" remove="true"/>
     </body>
 </page>
-
-
-

--- a/view/frontend/templates/creditcardthreedform.phtml
+++ b/view/frontend/templates/creditcardthreedform.phtml
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Shop System Plugins:
+ * - Terms of Use can be found under:
+ * https://github.com/wirecard/magento2-ee/blob/master/_TERMS_OF_USE
+ * - License can be found under:
+ * https://github.com/wirecard/magento2-ee/blob/master/LICENSE
+ */
+
+?>
+<form id="wirecard_elasticengine_credit_card_three_d_form" method="<?= $this->getMethod() ?>" action="<?= $this->getAction() ?>">
+    <?php foreach($this->getFormFields() as $name => $value): ?>
+        <input type="hidden" name="<?= $name ?>" value="<?= urldecode($value) ?>" />
+    <?php endforeach; ?>
+</form>


### PR DESCRIPTION
In this PR is the refactoring of the PHP code of Credit Card refactoring.

Changes:
- Remove unused form data code set in the session
- Update Callback.php class to support multiple result types
- Add template for ThreeDForm into the backed away from javascript